### PR TITLE
Fix aws_region deprecation warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,9 +3,7 @@ provider "aws" {
 }
 
 terraform {
-  required_version = ">= 0.11.0"
+  required_version = ">= 0.11.8"
 }
 
-data "aws_region" "current" {
-  current = true
-}
+data "aws_region" "current" {}


### PR DESCRIPTION
Fixing this:
```
Warning: module.s3_backend.data.aws_region.current: "current": [DEPRECATED] Defaults to current provider region if no other filtering is enabled
```